### PR TITLE
make notice_type.description usable in templates

### DIFF
--- a/notification/models.py
+++ b/notification/models.py
@@ -298,7 +298,7 @@ def send_now(users, label, extra_context=None, on_site=True, sender=None):
         context = Context({
             "recipient": user,
             "sender": sender,
-            "notice": ugettext(notice_type.display),
+            "notice": notice_type,
             "notices_url": notices_url,
             "current_site": current_site,
         })

--- a/notification/templates/notification/full.html
+++ b/notification/templates/notification/full.html
@@ -1,3 +1,3 @@
 {% load i18n %}
-<h3>{% blocktrans %}{{ notice.display }}{% endblocktrans %}</h3>
-<p>{% blocktrans %}{{ notice.description }}{% endblocktrans %}</p>
+<h3>{% blocktrans with title=notice.display %}{{ title }}{% endblocktrans %}</h3>
+<p>{% blocktrans with description=notice.description %}{{ description }}{% endblocktrans %}</p>

--- a/notification/templates/notification/full.html
+++ b/notification/templates/notification/full.html
@@ -1,1 +1,3 @@
-{% load i18n %}{% blocktrans %}{{ notice }}{% endblocktrans %}
+{% load i18n %}
+<h3>{% blocktrans %}{{ notice.display }}{% endblocktrans %}</h3>
+<p>{% blocktrans %}{{ notice.description }}{% endblocktrans %}</p>

--- a/notification/templates/notification/full.txt
+++ b/notification/templates/notification/full.txt
@@ -1,2 +1,2 @@
-{% load i18n %}{% blocktrans %}{{ notice.display }}{% endblocktrans %}
-{% blocktrans %}{{ notice.description }}{% endblocktrans %}
+{% load i18n %}{% blocktrans with title=notice.display %}{{ title }}{% endblocktrans %}
+{% blocktrans with description=notice.description %}{{ description }}{% endblocktrans %}

--- a/notification/templates/notification/full.txt
+++ b/notification/templates/notification/full.txt
@@ -1,1 +1,2 @@
-{% load i18n %}{% blocktrans %}{{ notice }}{% endblocktrans %}
+{% load i18n %}{% blocktrans %}{{ notice.display }}{% endblocktrans %}
+{% blocktrans %}{{ notice.description }}{% endblocktrans %}

--- a/notification/templates/notification/notice.html
+++ b/notification/templates/notification/notice.html
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktrans %}{{ notice }}{% endblocktrans %}
+{% load i18n %}{% blocktrans %}{{ notice.display }}{% endblocktrans %}

--- a/notification/templates/notification/notice.html
+++ b/notification/templates/notification/notice.html
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktrans %}{{ notice.display }}{% endblocktrans %}
+{% load i18n %}{% blocktrans with message=notice.display %}{{ message }}{% endblocktrans %}

--- a/notification/templates/notification/short.txt
+++ b/notification/templates/notification/short.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktrans %}{{ notice }}{% endblocktrans %}
+{% load i18n %}{% blocktrans %}{{ notice.display }}{% endblocktrans %}

--- a/notification/templates/notification/short.txt
+++ b/notification/templates/notification/short.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktrans %}{{ notice.display }}{% endblocktrans %}
+{% load i18n %}{% blocktrans with message=notice.display %}{{ message }}{% endblocktrans %}


### PR DESCRIPTION
I set up a bunch of notice types in my project, using the 'display' field as a title and 'description' field as a description.

When I came to designing the notification email templates I found there was no way (?) to access the description field from the templates.  I guess this was deliberate - I was supposed to use the 'display' field as sole text to show the user and 'description' is just visible in admin.  But I thought it'd be handy. And what if you wanted to extend the NoticeType to have extra fields? (being able to plug in your own notice type model would be great, I haven't gone that far yet)

So I've patched the send_now method to pass the whole NoticeType model instance into the templates, instead of just its display value.

I did some changes to the templates to accommodate, though the blocktrans syntax gets ugly (and is different in Django 1.2 - I've used 1.3 syntax here). Or I think just changing the **unicode** method of NoticeType to return self.display instead of self.label would let the old templates work. Wasn't sure if that was a good idea though.
