### PR TITLE
Support for sending html mails

### DIFF
--- a/notification/models.py
+++ b/notification/models.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.db.models.query import QuerySet
 from django.conf import settings
 from django.core.mail import send_mail
+from django.core.mail import EmailMultiAlternatives
 from django.core.urlresolvers import reverse
 from django.template import Context
 from django.template.loader import render_to_string
@@ -316,11 +317,21 @@ def send_now(users, label, extra_context=None, on_site=True, sender=None):
             'message': messages['full.txt'],
         }, context)
 
+        if(messages['full.html']):
+            html_body = render_to_string('notification/email_body.html', {
+                'message': messages['full.html'],
+            }, context)
+
         notice = Notice.objects.create(recipient=user, message=messages['notice.html'],
             notice_type=notice_type, on_site=on_site, sender=sender)
+
         if should_send(user, notice_type, "1") and user.email and user.is_active: # Email
             recipients.append(user.email)
-        send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, recipients)
+
+        msg = EmailMultiAlternatives(subject, body, settings.DEFAULT_FROM_EMAIL, recipients)
+        msg.attach_alternative(html_body, "text/html")
+        msg.send()
+        #send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, recipients)
 
     # reset environment to original language
     activate(current_language)


### PR DESCRIPTION
Hi,

Added support for sending html mails using django EmilMultiAlternatives.

the folder structure and html mail template remains same. i.e full.html
