### PR TITLE
There is no need to save default NoticeSetting instances. Under some rar...

### DIFF
--- a/notification/atomformat.py
+++ b/notification/atomformat.py
@@ -81,7 +81,7 @@ class Feed(object):
     VALIDATE = True
     
     
-    def __init__(self, slug, feed_url):
+    def __init__(self, slug=None, feed_url=None):
         # @@@ slug and feed_url are not used yet
         pass
     

--- a/notification/models.py
+++ b/notification/models.py
@@ -80,7 +80,6 @@ def get_notification_setting(user, notice_type, medium):
     except NoticeSetting.DoesNotExist:
         default = (NOTICE_MEDIA_DEFAULTS[medium] <= notice_type.default)
         setting = NoticeSetting(user=user, notice_type=notice_type, medium=medium, send=default)
-        setting.save()
         return setting
 
 def should_send(user, notice_type, medium):

--- a/notification/views.py
+++ b/notification/views.py
@@ -1,9 +1,8 @@
 from django.core.urlresolvers import reverse
 from django.shortcuts import render_to_response, get_object_or_404
-from django.http import HttpResponseRedirect, Http404
+from django.http import HttpResponseRedirect, Http404, HttpResponse
 from django.template import RequestContext
 from django.contrib.auth.decorators import login_required
-from django.contrib.syndication.views import feed
 
 from notification.models import *
 from notification.decorators import basic_auth_required, simple_basic_auth_callback
@@ -15,11 +14,10 @@ def feed_for_user(request):
     """
     An atom feed for all unarchived :model:`notification.Notice`s for a user.
     """
-    url = "feed/%s" % request.user.username
-    return feed(request, url, {
-        "feed": NoticeUserFeed,
-    })
-
+    feedgen = NoticeUserFeed().get_feed(request.user.username)
+    response = HttpResponse(mimetype=feedgen.mime_type)
+    feedgen.write(response, 'utf-8')
+    return response
 
 @login_required
 def notices(request):


### PR DESCRIPTION
...e circumstances (impatient users firing off multiple requests in parallel) the .save() here could also result in:

IntegrityError: duplicate key value violates unique constraint "notification_noticesetting_user_id_key"
