### PR TITLE
Feed, not feed

### DIFF
--- a/notification/views.py
+++ b/notification/views.py
@@ -4,7 +4,7 @@ from django.http import HttpResponseRedirect, Http404
 from django.template import RequestContext
 
 from django.contrib.auth.decorators import login_required
-from django.contrib.syndication.views import feed
+from django.contrib.syndication.views import Feed
 
 from notification.models import *
 from notification.decorators import basic_auth_required, simple_basic_auth_callback
@@ -17,7 +17,7 @@ def feed_for_user(request):
     An atom feed for all unarchived :model:`notification.Notice`s for a user.
     """
     url = "feed/%s" % request.user.username
-    return feed(request, url, {
+    return Feed(request, url, {
         "feed": NoticeUserFeed,
     })
 


### PR DESCRIPTION
I dont know older versions but in Django 1.5, django.contrib.syndication.views has class Feed, not feed.
