### PR TITLE
Feed, not feed

### DIFF
--- a/notification/views.py
+++ b/notification/views.py
@@ -4,8 +4,12 @@ from django.http import HttpResponseRedirect, Http404
 from django.template import RequestContext
 
 from django.contrib.auth.decorators import login_required
-from django.contrib.syndication.views import feed
 
+try:
+	from django.contrib.syndication.views import feed
+except ImportError:
+	from django.contrib.syndication.views import Feed as feed
+	
 from notification.models import *
 from notification.decorators import basic_auth_required, simple_basic_auth_callback
 from notification.feeds import NoticeUserFeed


### PR DESCRIPTION
As I understand, django.contrib.syndication.views.feed is renamed to Feed in newer versions. So I put a try/except block which tries to import feed, otherwise imports Feed to the views.py This may resolve this problem.
